### PR TITLE
fix: rename sock5 to socks5

### DIFF
--- a/PacketTunnel/PacketTunnelProvider.swift
+++ b/PacketTunnel/PacketTunnelProvider.swift
@@ -29,11 +29,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     /// 在创建或启用隧道时调用，用于启动 Xray 核心、配置虚拟网卡并启动 Tun2SocksKit（Socks5 隧道）。
     ///
-    /// - Parameter options: 传递给隧道的键值对信息，通常包含 `sock5Port` 和 `path` 等。
+    /// - Parameter options: 传递给隧道的键值对信息，通常包含 `socks5Port` 和 `path` 等。
     /// - Throws: 若缺失必要信息或启动过程中发生错误，抛出相应的错误。
     override func startTunnel(options: [String: NSObject]? = nil) async throws {
         // 1. 从 options 中提取 SOCKS5 端口与配置文件路径
-        guard let sock5Port = options?["sock5Port"] as? Int else {
+        guard let socks5Port = options?["socks5Port"] as? Int else {
             throw NSError(domain: "PacketTunnel", code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "缺少 SOCKS5 端口配置"])
         }
@@ -51,7 +51,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             try await setTunnelNetworkSettings()
 
             // 4. 启动 SOCKS5 隧道（Tun2SocksKit）
-            try startSocks5Tunnel(serverPort: sock5Port)
+            try startSocks5Tunnel(serverPort: socks5Port)
 
         } catch {
             Logger().error("启动服务时发生错误: \(error.localizedDescription)")

--- a/Shared/Constant.swift
+++ b/Shared/Constant.swift
@@ -15,7 +15,7 @@ public enum Constant {
 public extension Constant {
     static let groupName = "group.\(Constant.packageName)"
     static let tunnelName = "\(Constant.packageName).PacketTunnel"
-    static let sock5Port: NWEndpoint.Port = 10808
+    static let socks5Port: NWEndpoint.Port = 10808
     static let trafficPort: NWEndpoint.Port = 49227
 
     private static func createDirectory(at url: URL) -> URL {

--- a/Xray/Configuration.swift
+++ b/Xray/Configuration.swift
@@ -35,7 +35,7 @@ struct Configuration {
     func buildRunConfigurationData(config: String) throws -> Data {
         // 1. 从 UserDefaults 中获取端口并转为 NWEndpoint.Port
         guard
-            let inboundPortString = Util.loadFromUserDefaults(key: "sock5Port"),
+            let inboundPortString = Util.loadFromUserDefaults(key: "socks5Port"),
             let trafficPortString = Util.loadFromUserDefaults(key: "trafficPort"),
             let inboundPort = NWEndpoint.Port(inboundPortString),
             let trafficPort = NWEndpoint.Port(trafficPortString)
@@ -76,7 +76,7 @@ struct Configuration {
     func buildPingConfigurationData(config: String) throws -> Data {
         // 1. 从 UserDefaults 中获取端口并转为 NWEndpoint.Port
         guard
-            let inboundPortString = Util.loadFromUserDefaults(key: "sock5Port"),
+            let inboundPortString = Util.loadFromUserDefaults(key: "socks5Port"),
             let inboundPort = NWEndpoint.Port(inboundPortString)
         else {
             throw NSError(

--- a/Xray/ContentView.swift
+++ b/Xray/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
     @State private var pingSpeed: Int = 0
 
     /// 用于在界面上显示 SOCKS 端口（本地代理端口）。
-    @State private var sock5Port: String = ""
+    @State private var socks5Port: String = ""
 
     /// 用于在界面上显示流量统计端口。
     @State private var trafficPort: String = ""
@@ -95,7 +95,7 @@ struct ContentView: View {
                 Text("本机端口:")
                     .font(.headline)
                 HStack {
-                    Text("Sock5: \(sock5Port)")
+                    Text("Socks5: \(socks5Port)")
                     Spacer()
                     Text("流量: \(trafficPort)")
                 }
@@ -271,9 +271,9 @@ struct ContentView: View {
                let ports = dataDict["ports"] as? [Int], ports.count == 2
             {
                 // 4. 保存端口到 UserDefaults，并更新本地状态
-                Util.saveToUserDefaults(value: String(ports[0]), key: "sock5Port")
+                Util.saveToUserDefaults(value: String(ports[0]), key: "socks5Port")
                 Util.saveToUserDefaults(value: String(ports[1]), key: "trafficPort")
-                sock5Port = String(ports[0])
+                socks5Port = String(ports[0])
                 trafficPort = String(ports[1])
 
                 logger.info("获取到的端口: \(ports[0]), \(ports[1])")

--- a/Xray/PacketTunnelManager.swift
+++ b/Xray/PacketTunnelManager.swift
@@ -198,8 +198,8 @@ final class PacketTunnelManager: ObservableObject {
         try await saveAndLoad(manager: manager)
 
         // 3. 从 UserDefaults 加载 SOCKS 端口和配置链接
-        guard let sock5PortString = Util.loadFromUserDefaults(key: "sock5Port"),
-              let sock5Port = Int(sock5PortString)
+        guard let socks5PortString = Util.loadFromUserDefaults(key: "socks5Port"),
+              let socks5Port = Int(socks5PortString)
         else {
             throw NSError(domain: "ConfigurationError", code: -1,
                           userInfo: [NSLocalizedDescriptionKey: "无法从 UserDefaults 加载端口或端口格式不正确"])
@@ -227,7 +227,7 @@ final class PacketTunnelManager: ObservableObject {
         // 6. 正式启动 VPN，传入 SOCKS 端口和配置文件路径
         do {
             try manager.connection.startVPNTunnel(options: [
-                "sock5Port": sock5Port as NSNumber,
+                "socks5Port": socks5Port as NSNumber,
                 "path": fileUrl.path as NSString,
             ])
             logger.info("VPN 尝试启动")

--- a/Xray/PingView.swift
+++ b/Xray/PingView.swift
@@ -97,8 +97,8 @@ struct PingView: View {
                 let fileUrl = try Util.createConfigFile(with: mergedConfigString)
 
                 // 4. 读取 SOCKS5 代理端口
-                guard let sock5PortString = Util.loadFromUserDefaults(key: "sock5Port"),
-                      let sock5Port = NWEndpoint.Port(sock5PortString)
+                guard let socks5PortString = Util.loadFromUserDefaults(key: "socks5Port"),
+                      let socks5Port = NWEndpoint.Port(socks5PortString)
                 else {
                     throw NSError(
                         domain: "ConfigurationError",
@@ -110,7 +110,7 @@ struct PingView: View {
                 // 5. 构造 Ping 请求
                 let pingRequest = try createPingRequest(
                     configPath: fileUrl.path(),
-                    sock5Port: sock5Port
+                    socks5Port: socks5Port
                 )
 
                 // 6. 将请求转换成 Base64 再调用 LibXrayPing
@@ -164,17 +164,17 @@ struct PingView: View {
     ///
     /// - Parameters:
     ///   - configPath: 配置文件在本地的路径。
-    ///   - sock5Port: SOCKS5 代理使用的端口号。
+    ///   - socks5Port: SOCKS5 代理使用的端口号。
     /// - Throws: 当参数无效时可能抛出错误。
     /// - Returns: 生成的 `PingRequest` 对象。
     @MainActor
-    private func createPingRequest(configPath: String, sock5Port: NWEndpoint.Port) throws -> PingRequest {
+    private func createPingRequest(configPath: String, socks5Port: NWEndpoint.Port) throws -> PingRequest {
         PingRequest(
             datDir: Constant.assetDirectory.path, // 数据文件目录
             configPath: configPath, // Xray 配置文件路径
             timeout: 30, // 超时时间（秒）
             url: "https://1.1.1.1", // 用于检测的网络地址
-            proxy: "socks5://127.0.0.1:\(sock5Port)" // 使用的代理地址
+            proxy: "socks5://127.0.0.1:\(socks5Port)" // 使用的代理地址
         )
     }
 


### PR DESCRIPTION
## Summary
- rename sock5 references to socks5 across the project

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684a397e0674832e86e9476b098fd7c8